### PR TITLE
fix(pages): use relative path to main.css for GitHub Pages

### DIFF
--- a/pages/agency.html
+++ b/pages/agency.html
@@ -11,7 +11,7 @@
       href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="../assets/css/main.css" />
   </head>
   <body>
     <header class="site-header">


### PR DESCRIPTION
This pull request includes a minor update to the stylesheet link path in the `pages/agency.html` file to fix the reference to the main CSS file.

* Changed the `href` path for the main stylesheet from `/assets/css/main.css` to `../assets/css/main.css` to ensure the correct file is loaded.