### PR TITLE
Fix/japan ssw link

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -26,7 +26,7 @@
   - The header uses this structure in all pages:
       <header class="site-header">
         <div class="container header-inner">
-          <a class="brand" href="/">Brand</a>
+          <a class="brand" href="index.html">Brand</a>
           <nav class="site-nav" aria-label="Main navigation">...</nav>
           <div class="header-actions">...Signup / Log in...</div>
         </div>

--- a/docs/CSS_MAIN_GUIDE.md
+++ b/docs/CSS_MAIN_GUIDE.md
@@ -87,7 +87,7 @@ Markup example:
 ```html
 <header class="site-header">
   <div class="container header-inner">
-  <a class="brand" href="index.html">Japan SSW</a>
+    <a class="brand" href="index.html">Japan SSW</a>
     <nav class="site-nav" aria-label="Main navigation">
       <a href="#jobs">Jobs</a>
       <a href="#companies">Companies</a>

--- a/docs/CSS_MAIN_GUIDE.md
+++ b/docs/CSS_MAIN_GUIDE.md
@@ -87,7 +87,7 @@ Markup example:
 ```html
 <header class="site-header">
   <div class="container header-inner">
-    <a class="brand" href="/">Japan SSW</a>
+  <a class="brand" href="index.html">Japan SSW</a>
     <nav class="site-nav" aria-label="Main navigation">
       <a href="#jobs">Jobs</a>
       <a href="#companies">Companies</a>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
   <body>
     <header class="site-header">
       <div class="container header-inner">
-        <a class="brand" href="/index.html">Japan SSW</a>
+  <a class="brand" href="index.html">Japan SSW</a>
         <nav class="site-nav" aria-label="Main navigation">
           <a href="#jobs">Jobs</a>
           <a href="#companies">Companies</a>
@@ -243,7 +243,7 @@
           <div class="link-col">
             <h4>Company</h4>
             <ul>
-              <li><a href="/">Home</a></li>
+              <li><a href="index.html">Home</a></li>
               <li><a href="pages/about.html">About</a></li>
               <li><a href="pages/contact.html">Contact</a></li>
             </ul>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
   <body>
     <header class="site-header">
       <div class="container header-inner">
-  <a class="brand" href="index.html">Japan SSW</a>
+        <a class="brand" href="index.html">Japan SSW</a>
         <nav class="site-nav" aria-label="Main navigation">
           <a href="#jobs">Jobs</a>
           <a href="#companies">Companies</a>

--- a/pages/agency.html
+++ b/pages/agency.html
@@ -11,7 +11,7 @@
       href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap"
       rel="stylesheet"
     />
-  <link rel="stylesheet" href="../assets/css/main.css" />
+    <link rel="stylesheet" href="../assets/css/main.css" />
   </head>
   <body>
     <header class="site-header">

--- a/pages/agency.html
+++ b/pages/agency.html
@@ -45,7 +45,7 @@
         </section>
 
         <p class="mt-lg">
-          <a class="btn btn-primary" href="/">Back to Home</a>
+          <a class="btn btn-primary" href="../index.html">Back to Home</a>
         </p>
       </div>
     </main>


### PR DESCRIPTION
This pull request updates navigation links throughout the site to consistently use relative paths to `index.html` instead of root (`/`). This ensures the links work correctly regardless of deployment environment or directory structure.

Navigation link updates:

* Changed the `href` of the brand link in the header from `/` to `index.html` in `assets/css/main.css`, `docs/CSS_MAIN_GUIDE.md`, and `index.html` for consistency and reliability. [[1]](diffhunk://#diff-b15932692c619f9a334ecb156ac167557c3af214a8a3df8990c09232ac8a5baaL29-R29) [[2]](diffhunk://#diff-c2ef68255c7758a74b3e9627a16a4326d07e444858b0d2ae4d856950e4d8bf92L90-R90) [[3]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L44-R44)
* Updated the "Home" link in the company section from `/` to `index.html` in `index.html`.
* Changed the "Back to Home" button link from `/` to `../index.html` in `pages/agency.html` to correctly navigate back from a subdirectory.