### PR TITLE
Add Job Profile page (HTML+CSS only) per Figma design

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1931,3 +1931,77 @@ body.profile-dashboard .bento-box--split .bento-box__inner {
   height: auto;
 }
 
+/* ===========================
+   Job Detail Page (HTML+CSS)
+   Author: MK
+   =========================== */
+.job-card-wrap {
+  background: #f5f5f5;
+  padding: 1.25rem 0 2.5rem;
+}
+
+.job-card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: var(--box-shadow);
+  padding: 1.25rem 1.25rem 1.5rem;
+  position: relative;
+}
+@media (min-width: 900px) { .job-card { padding: 1.5rem 2rem 2rem; } }
+
+.job-card__head {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: .75rem; margin-bottom: .5rem;
+}
+.job-card__crumb {
+  display: inline-flex; align-items: center;
+  font-size: 12px; font-weight: 600; color: var(--dark-color);
+  background: #f7f7f7; border: 1px solid rgba(0,0,0,.06);
+  padding: .35rem .6rem; border-radius: 999px;
+}
+.job-card__cta-top { padding: .55rem 1rem; border-radius: 999px; }
+
+.job-card__title { margin: .25rem 0 .25rem; font-size: 1.6rem; line-height: 1.25; }
+@media (min-width: 900px) { .job-card__title { font-size: 2rem; } }
+
+.job-card__meta { margin: 0 0 1rem; }
+
+/* Grid for Conditions / Requirements */
+.job-spec {
+  display: grid; grid-template-columns: 1fr; gap: 1rem; margin-bottom: 1.25rem;
+}
+@media (min-width: 900px) {
+  .job-spec { grid-template-columns: 1fr 1fr; gap: 1.25rem; }
+}
+.job-spec__col {
+  border: 1px solid rgba(0,0,0,.06);
+  border-radius: 10px; background: #fff; padding: .9rem 1rem;
+}
+.job-spec__title { font-size: 1rem; margin: 0 0 .5rem; }
+.job-spec__list { list-style: none; padding: 0; margin: 0; display: grid; gap: .5rem; }
+
+.job-pill {
+  border: 1px solid rgba(0,0,0,.08);
+  background: #fafafa;
+  border-radius: 10px;
+  padding: .6rem .75rem;
+  display: grid; gap: .15rem;
+  font-size: .95rem;
+}
+.job-pill--accent { background: rgba(235,0,0,.04); border-color: rgba(235,0,0,.15); }
+.job-pill__icon { font-size: 1rem; margin-right: .25rem; }
+.job-pill__note { display: block; color: rgba(0,0,0,.55); font-size: .8rem; margin-top: .1rem; }
+
+.job-body { display: grid; gap: 1.25rem; }
+.job-body h2 { font-size: 1.125rem; margin: .25rem 0 .5rem; }
+.job-link { color: var(--accent-color); text-decoration: underline; }
+
+/* Sticky bottom CTA (follows comp) */
+.job-sticky-cta {
+  position: sticky; bottom: 0; z-index: 30;
+  background: linear-gradient(to top, rgba(255,255,255,1), rgba(255,255,255,.92));
+  border-top: 1px solid rgba(0,0,0,.06);
+  padding: .6rem 0;
+}
+.job-sticky-cta__inner { display: flex; justify-content: center; }
+.job-sticky-cta__btn { padding: .7rem 1.25rem; border-radius: 999px; }

--- a/pages/job.html
+++ b/pages/job.html
@@ -1,0 +1,182 @@
+<!-- Author MK -->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Ground Handling Support (Haneda) – Japan SSW</title>
+
+  <!-- Fonts (same as other pages) -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet" />
+
+  <!-- Project CSS -->
+  <link rel="stylesheet" href="../assets/css/main.css" />
+  <link rel="icon" type="image/x-icon" href="../assets/icons/favicon.ico" />
+</head>
+<body>
+  <!-- Shared Header -->
+  <header class="site-header">
+    <div class="container site-header__inner">
+      <a class="site-header__brand" href="../index.html">Japan SSW</a>
+      <nav class="site-header__nav" aria-label="Main navigation">
+        <a class="site-header__nav-link" href="../index.html#jobs">Jobs</a>
+        <a class="site-header__nav-link" href="../index.html#companies">Companies</a>
+        <a class="site-header__nav-link" href="../pages/agency.html">Agency</a>
+        <a class="site-header__nav-link" href="../pages/about.html">About</a>
+      </nav>
+      <div class="site-header__actions">
+        <a class="site-header__signup muted" href="../pages/createAccount.html">Signup</a>
+        <a class="btn btn-primary site-header__login-btn" href="../pages/signin.html">Log in</a>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <!-- Job header card -->
+    <section class="job-card-wrap">
+      <div class="container">
+        <article class="job-card" aria-labelledby="job-title">
+          <header class="job-card__head">
+            <div class="job-card__crumb" aria-label="Company">Kaisha</div>
+            <a class="btn btn-primary job-card__cta-top" href="#apply">Apply now →</a>
+          </header>
+
+          <h1 id="job-title" class="job-card__title">Ground Handling Support (Haneda)</h1>
+
+          <p class="job-card__meta muted">
+            Tokyo • Aviation • Full time • <time datetime="2024-11-01">November 1, 2024</time>
+          </p>
+
+          <!-- Conditions / Requirements -->
+          <div class="job-spec">
+            <section class="job-spec__col" aria-labelledby="cond-title">
+              <h2 id="cond-title" class="job-spec__title">Conditions</h2>
+              <ul class="job-spec__list">
+                <li class="job-pill"><span class="job-pill__icon" aria-hidden="true">💴</span> V/M → VTM / yr</li>
+                <li class="job-pill"><span class="job-pill__icon" aria-hidden="true">🌐</span> Apply from <strong>Anywhere</strong></li>
+                <li class="job-pill job-pill--accent">
+                  <span class="job-pill__icon" aria-hidden="true">🛄</span>
+                  Relocation to <strong>Japan</strong>
+                  <small class="job-pill__note">(Overseas visa sponsorship supported)</small>
+                </li>
+              </ul>
+            </section>
+
+            <section class="job-spec__col" aria-labelledby="req-title">
+              <h2 id="req-title" class="job-spec__title">Requirements</h2>
+              <ul class="job-spec__list">
+                <li class="job-pill">
+                  <span class="job-pill__icon" aria-hidden="true">🗣️</span>
+                  <strong>Language Requirements</strong><br>
+                  Japanese: <strong>Conversation / N3</strong><br>
+                  English: <span class="muted">Not Required</span>
+                </li>
+                <li class="job-pill">
+                  <span class="job-pill__icon" aria-hidden="true">🎯</span>
+                  <strong>Minimum Experience</strong><br>
+                  <span class="muted">No Experience Needed</span>
+                </li>
+              </ul>
+            </section>
+          </div>
+
+          <!-- Body copy -->
+          <div class="job-body">
+            <section>
+              <h2>Department Overview</h2>
+              <p>Lorem ipsum dolor sit amet consectetur. Lucas amet justo maecenas in at… <a href="#" class="job-link">Click here.</a></p>
+              <p>Lorem ipsum dolor sit amet consectetur. Tellus integer…</p>
+              <p>Lorem ipsum dolor sit amet consectetur. Nulla pellentesque…</p>
+            </section>
+
+            <section>
+              <h2>Why We Hire</h2>
+              <p>Lorem ipsum dolor sit amet consectetur. Dolorum voluptate…</p>
+            </section>
+
+            <section>
+              <h2>Position Details</h2>
+              <p>Lorem ipsum dolor sit amet consectetur. Massa arcu adipiscing…</p>
+              <ul>
+                <li>Lorem ipsum dolor sit amet consectetur. Scelerisque convallis…</li>
+                <li>Lorem ipsum dolor sit amet consectetur. Donec bibendum…</li>
+                <li>Lorem ipsum dolor sit amet consectetur. Cum eleifend…</li>
+              </ul>
+            </section>
+
+            <section>
+              <h2>Mandatory Qualifications</h2>
+              <ul>
+                <li>Lorem ipsum dolor sit amet consectetur.</li>
+                <li>Nibh viverra quis id mollis.</li>
+                <li>Duis laoreet ultricies dolor.</li>
+                <li>Non sed et pellentesque augue ligula.</li>
+                <li>Urna sed ut ultrices neque bibendum.</li>
+                <li>Curabitur a commodo felis.</li>
+              </ul>
+            </section>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <!-- Sticky bottom apply -->
+    <div class="job-sticky-cta" role="region" aria-label="Apply now">
+      <div class="container job-sticky-cta__inner">
+        <a id="apply" class="btn btn-primary job-sticky-cta__btn" href="../pages/signin.html">Apply now →</a>
+      </div>
+    </div>
+  </main>
+
+  <!-- Shared Footer -->
+  <footer class="site-footer site-footer--dark" role="contentinfo">
+    <div class="container footer-grid site-footer__grid">
+      <div class="footer-cta site-footer__cta">
+        <h3>Want to post jobs on JapanSSW?</h3>
+        <p class="muted site-footer__cta-muted">Reach qualified candidates under the SSW programme.</p>
+        <div class="footer-cta-actions site-footer__cta-actions">
+          <a class="btn btn-secondary" href="../">Employer Login</a>
+          <a class="btn btn-primary" href="../index.html#post-job">Post a Job</a>
+        </div>
+      </div>
+      <div class="footer-links site-footer__links">
+        <div class="link-col site-footer__link-col">
+          <h4>Company</h4>
+          <ul>
+            <li><a href="../">Home</a></li>
+            <li><a href="../pages/about.html">About</a></li>
+            <li><a href="../pages/contact.html">Contact</a></li>
+          </ul>
+        </div>
+        <div class="link-col site-footer__link-col">
+          <h4>Jobs</h4>
+          <ul>
+            <li><a href="../index.html#jobs">Search Jobs</a></li>
+            <li><a href="../index.html#companies">Companies</a></li>
+            <li><a href="../index.html#post-job">Post a Job</a></li>
+          </ul>
+        </div>
+        <div class="link-col site-footer__link-col">
+          <h4>Resources</h4>
+          <ul>
+            <li><a href="#">Visa Guidance</a></li>
+            <li><a href="#">Employer Hub</a></li>
+            <li><a href="#">Privacy</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="container footer-legal site-footer__legal">
+      <div class="legal-inner site-footer__legal-inner">
+        <small>&copy; 2025 Japan SSW. All rights reserved.</small>
+        <nav aria-label="Footer legal">
+          <a href="#">Terms</a>
+          <a href="#">Privacy</a>
+        </nav>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
This pull request introduces a new job detail page to the project, providing both the HTML structure and accompanying CSS styles for a modern, responsive job listing. The changes include a dedicated `job.html` page and a suite of new CSS classes to style job cards, requirements, and sticky call-to-action elements.

**New Job Detail Page Implementation:**

* Added a new HTML file `pages/job.html` featuring a detailed job listing, including company info, conditions, requirements, job description sections, and a sticky apply button.

**Styling for Job Detail Components:**

* Introduced new CSS classes in `assets/css/main.css` for job card layout, conditions/requirements grid, pill-style tags, and sticky bottom call-to-action, ensuring a clean and responsive design for the job detail page.