### PR TITLE
Update close button links in add/edit pages for correct navigation

### DIFF
--- a/pages/addEdit/contact.html
+++ b/pages/addEdit/contact.html
@@ -20,7 +20,7 @@
       <!-- Header -->
       <div class="flex justify-between items-center mb-6">
         <h1 class="text-2xl font-bold text-gray-800">Add/Edit Contact</h1>
-        <a href="../../../index.html" class="text-gray-500 hover:text-gray-700 font-bold">
+        <a href="../../index.html" class="text-gray-500 hover:text-gray-700 font-bold">
           close
         </a>
       </div>

--- a/pages/addEdit/education.html
+++ b/pages/addEdit/education.html
@@ -20,7 +20,7 @@
       <!-- Header -->
       <div class="flex justify-between items-center mb-6">
         <h1 class="text-2xl font-bold text-gray-800">Add/Edit Education</h1>
-        <a href="../../../index.html" class="text-gray-500 hover:text-gray-700 font-bold">
+        <a href="../../index.html" class="text-gray-500 hover:text-gray-700 font-bold">
           close
         </a>
       </div>

--- a/pages/addEdit/experience.html
+++ b/pages/addEdit/experience.html
@@ -20,7 +20,7 @@
       <!-- Header -->
       <div class="flex justify-between items-center mb-6">
         <h1 class="text-2xl font-bold text-gray-800">Add/Edit Experience</h1>
-        <a href="../../../index.html" class="text-gray-500 hover:text-gray-700 font-bold">
+        <a href="../../index.html" class="text-gray-500 hover:text-gray-700 font-bold">
           close
         </a>
       </div>

--- a/pages/addEdit/profile.html
+++ b/pages/addEdit/profile.html
@@ -21,7 +21,7 @@
       <!-- Header -->
       <div class="flex justify-between items-center mb-6">
         <h1 class="text-2xl font-bold text-gray-800">Add/Edit Profile</h1>
-        <a href="../../../index.html" class="text-gray-500 hover:text-gray-700 font-bold">
+        <a href="../../index.html" class="text-gray-500 hover:text-gray-700 font-bold">
           close
         </a>
       </div>

--- a/pages/addEdit/skill.html
+++ b/pages/addEdit/skill.html
@@ -20,7 +20,7 @@
       <!-- Header -->
       <div class="flex justify-between items-center mb-6">
         <h1 class="text-2xl font-bold text-gray-800">Add Skill</h1>
-        <a href="../../../index.html" class="text-gray-500 hover:text-gray-700 font-bold">
+        <a href="../../index.html" class="text-gray-500 hover:text-gray-700 font-bold">
           close
         </a>
       </div>


### PR DESCRIPTION
This pull request updates the navigation links in the header of several add/edit pages to improve their relative paths. Now, the "close" button on each page correctly links back to the main `index.html` page.

Navigation link updates:

* Changed the "close" button link in `contact.html` to point to `../../index.html` instead of `../../../index.html`.
* Changed the "close" button link in `education.html` to point to `../../index.html` instead of `../../../index.html`.
* Changed the "close" button link in `experience.html` to point to `../../index.html` instead of `../../../index.html`.
* Changed the "close" button link in `profile.html` to point to `../../index.html` instead of `../../../index.html`.
* Changed the "close" button link in `skill.html` to point to `../../index.html` instead of `../../../index.html`.