### PR TITLE
Fix/fix profile page navlinks

### DIFF
--- a/pages/profileDashboard.html
+++ b/pages/profileDashboard.html
@@ -12,10 +12,10 @@
       <div class="container site-header__inner">
         <a class="site-header__brand" href="../index.html">Japan SSW</a>
         <nav class="site-header__nav" aria-label="Main navigation">
-          <a class="site-header__nav-link" href="#jobs">Jobs</a>
-          <a class="site-header__nav-link" href="#companies">Companies</a>
-          <a class="site-header__nav-link" href="pages/agency.html">Agency</a>
-          <a class="site-header__nav-link" href="pages/about.html">About</a>
+          <a class="site-header__nav-link" href="../index.html#jobs">Jobs</a>
+          <a class="site-header__nav-link" href="../index.html#companies">Companies</a>
+          <a class="site-header__nav-link" href="agency.html">Agency</a>
+          <a class="site-header__nav-link" href="about.html">About</a>
         </nav>
       </div>
     </header>

--- a/pages/profileDashboard.html
+++ b/pages/profileDashboard.html
@@ -13,7 +13,9 @@
         <a class="site-header__brand" href="../index.html">Japan SSW</a>
         <nav class="site-header__nav" aria-label="Main navigation">
           <a class="site-header__nav-link" href="../index.html#jobs">Jobs</a>
-          <a class="site-header__nav-link" href="../index.html#companies">Companies</a>
+          <a class="site-header__nav-link" href="../index.html#companies"
+            >Companies</a
+          >
           <a class="site-header__nav-link" href="agency.html">Agency</a>
           <a class="site-header__nav-link" href="about.html">About</a>
         </nav>


### PR DESCRIPTION
This pull request updates navigation links in the header of the `pages/profileDashboard.html` file to improve routing and consistency.

Navigation link updates:

* Changed the `Jobs` and `Companies` links to reference anchor sections on the main `index.html` page, ensuring correct navigation from the dashboard.
* Updated the `Agency` and `About` links to use local paths (`agency.html` and `about.html`), removing the unnecessary `pages/` prefix for consistency with the current file structure.