### PR TITLE
Update footer links to use relative paths for Terms and Privacy pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -564,8 +564,8 @@
         <div class="legal-inner site-footer__legal-inner">
           <small>&copy; 2025 Japan SSW. All rights reserved.</small>
           <nav aria-label="Footer legal">
-            <a href="/pages/terms.html">Terms</a>
-            <a href="/pages/privacy.html">Privacy</a>
+            <a href="pages/terms.html">Terms</a>
+            <a href="pages/privacy.html">Privacy</a>
           </nav>
         </div>
       </div>

--- a/pages/about.html
+++ b/pages/about.html
@@ -173,8 +173,8 @@
         <div class="legal-inner site-footer__legal-inner">
           <small>&copy; 2025 Japan SSW. All rights reserved.</small>
           <nav aria-label="Footer legal">
-            <a href="/pages/terms.html">Terms</a>
-            <a href="/pages/privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="privacy.html">Privacy</a>
           </nav>
         </div>
       </div>

--- a/pages/createAccount.html
+++ b/pages/createAccount.html
@@ -114,8 +114,8 @@
                 <div class="legal-inner site-footer__legal-inner">
                     <small>&copy; 2025 Japan SSW. All rights reserved.</small>
                     <nav aria-label="Footer legal">
-                        <a href="/pages/terms.html">Terms</a>
-                        <a href="/pages/privacy.html">Privacy</a>
+                        <a href="terms.html">Terms</a>
+                        <a href="privacy.html">Privacy</a>
                     </nav>
                 </div>
             </div>

--- a/pages/signin.html
+++ b/pages/signin.html
@@ -113,8 +113,8 @@
                 <div class="legal-inner site-footer__legal-inner">
                     <small>&copy; 2025 Japan SSW. All rights reserved.</small>
                     <nav aria-label="Footer legal">
-                        <a href="/pages/terms.html">Terms</a>
-                        <a href="/pages/privacy.html">Privacy</a>
+                        <a href="terms.html">Terms</a>
+                        <a href="privacy.html">Privacy</a>
                     </nav>
                 </div>
             </div>

--- a/pages/terms.html
+++ b/pages/terms.html
@@ -93,8 +93,8 @@
         <div class="legal-inner site-footer__legal-inner">
           <small>&copy; 2025 Japan SSW. All rights reserved.</small>
           <nav aria-label="Footer legal">
-            <a href="/pages/terms.html">Terms</a>
-            <a href="/pages/privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="privacy.html">Privacy</a>
           </nav>
         </div>
       </div>


### PR DESCRIPTION
This pull request updates the footer navigation links for the "Terms" and "Privacy" pages across multiple HTML files to use relative paths instead of absolute paths. This change ensures consistent and correct linking to these pages regardless of the current page location within the site structure.

Footer navigation link updates:

* Changed the "Terms" and "Privacy" footer links in `index.html` to use relative paths (`pages/terms.html` and `pages/privacy.html`) instead of absolute paths (`/pages/terms.html` and `/pages/privacy.html`).
* Updated the "Terms" and "Privacy" footer links in `pages/about.html`, `pages/createAccount.html`, `pages/signin.html`, and `pages/terms.html` to use local relative links (`terms.html` and `privacy.html`) for improved navigation consistency. [[1]](diffhunk://#diff-9ddfd3b5b96d22475bea3d6477e507613fd0ddd610444a2189f01543414357f1L176-R177) [[2]](diffhunk://#diff-35f393026831fb908b1e6c0826a2dd4e4618f377b509f74f02d8c3030bf055f5L117-R118) [[3]](diffhunk://#diff-a184dc435e9b224ee0e1c39edc0f8fa03ede883c10e8b9ad1a9942925f8780a0L116-R117) [[4]](diffhunk://#diff-30719971bab96853351b3d91014b84db544569c6cdd7d78969e603375ace83b0L96-R97)