### PR TITLE
Update privacy link to use relative path in createAccount.html

### DIFF
--- a/pages/createAccount.html
+++ b/pages/createAccount.html
@@ -54,7 +54,7 @@
                     <div class="flex items-center justify-between">
                         <div class="flex items-center">
                             <input id="remember-me" name="remember-me" type="checkbox" required aria-required="true" class="h-4 w-4 text-red-600 focus:ring-red-500 border-gray-300 rounded">
-                            <label for="remember-me" class="ml-2 block text-sm text-gray-900">I agree to the <a href="/pages/privacy.html" target="_blank" rel="noopener noreferrer">Privacy Policy</a></label>
+                            <label for="remember-me" class="ml-2 block text-sm text-gray-900">I agree to the <a href="privacy.html" target="_blank" rel="noopener noreferrer">Privacy Policy</a></label>
                         </div>
                         <a href="#" class="text-sm text-gray-500 hover:text-red-500">Forgot Password?</a>
                     </div>
@@ -105,7 +105,7 @@
                         <ul>
                             <li><a href="#">Visa Guidance</a></li>
                             <li><a href="#">Employer Hub</a></li>
-                            <li><a href="/pages/privacy.html">Privacy</a></li>
+                            <li><a href="privacy.html">Privacy</a></li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
This pull request makes minor updates to the `pages/createAccount.html` file to fix the links to the Privacy Policy. The changes ensure that the Privacy Policy link is correctly referenced relative to the current directory.

* Updated the Privacy Policy link in the "I agree to the Privacy Policy" checkbox label to use a relative path (`privacy.html` instead of `/pages/privacy.html`).
* Updated the Privacy Policy link in the Resources list to use a relative path (`privacy.html` instead of `/pages/privacy.html`).