### PR TITLE
Feature/addimage on signuppage

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -162,6 +162,12 @@ button {
   font-weight: 700;
 }
 
+/* Small button modifier for secondary actions */
+.btn--small {
+  padding: 0.45rem 0.7rem;
+  font-size: 13px;
+}
+
 /* Japanese font stack for elements where lang=ja or .jp is used */
 :lang(ja),
 .jp {
@@ -396,6 +402,58 @@ button {
   border-radius: 12px;
   box-shadow: 0 6px 18px rgba(15, 23, 42, 0.06);
   margin-bottom: 1rem;
+}
+
+/* Agency list — responsive card/grid layout used on pages/agency.html */
+.agency-list {
+  list-style: none; /* remove bullets */
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr; /* stack on small screens */
+}
+
+.agency-item {
+  background: var(--light-color);
+  padding: 1.25rem;
+  border-radius: 12px;
+  box-shadow: var(--box-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center; /* center content on small screens */
+  text-align: center;
+}
+
+.agency-item__name {
+  margin: 0 0 0.25rem;
+}
+
+.agency-item__desc {
+  margin: 0 0 0.75rem;
+}
+
+.agency-item .btn {
+  margin-top: 0.5rem;
+}
+
+/* Desktop / tablet layout: two columns, left-align card content */
+@media (min-width: 768px) {
+  .agency-list {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.25rem;
+  }
+  .feature-card {
+    text-align: left; /* make overall feature-card left aligned on larger screens */
+  }
+  .agency-item {
+    align-items: flex-start;
+    text-align: left;
+  }
+  .agency-item .btn {
+    align-self: flex-start; /* keep CTA aligned with content */
+  }
 }
 
 /* Job panels for job listings */

--- a/pages/agency.html
+++ b/pages/agency.html
@@ -38,20 +38,188 @@
 
     <main class="section-padding">
       <div class="container">
-        <h1>Agency (Placeholder)</h1>
-        <p class="muted">
-          This is a placeholder page for Agency. Replace with real content.
-        </p>
-
-        <section class="feature-card mt-md">
-          <h2 class="feature-card__title">Registered Support Organizations</h2>
+        <section class="feature-card mt-md" aria-labelledby="rso-heading">
+          <h2 id="rso-heading" class="feature-card__title">
+            Registered Support Organizations
+          </h2>
           <p class="muted feature-card__desc">
-            List of agencies and short descriptions will go here.
+            Below are a selection of organisations and agencies that assist
+            employers and candidates with the SSW programme. Click through to
+            learn more or contact them directly.
           </p>
+
+          <ul class="agency-list mt-md">
+            <li class="agency-item">
+              <h3 class="agency-item__name">
+                Gurutto Corporation (Registration Support Organization)
+              </h3>
+              <p class="muted agency-item__desc">
+                Provides employer and candidate support under regional programs.
+                See their listing and contact information.
+              </p>
+              <a
+                class="btn btn-secondary"
+                href="https://ph.gurutto-asia.com/digest/category-1/search/sub-category-9/"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Visit Gurutto listing</a
+              >
+            </li>
+
+            <li class="agency-item">
+              <h3 class="agency-item__name">
+                THRIVE Business Cooperative Association
+              </h3>
+              <p class="muted agency-item__desc">
+                A business cooperative offering support services and community
+                integration assistance in Miyagi.
+              </p>
+              <a
+                class="btn btn-secondary"
+                href="https://thrive-miyagi.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Visit THRIVE</a
+              >
+            </li>
+
+            <li class="agency-item">
+              <h3 class="agency-item__name">
+                Hokkaido Human Resource Development Cooperative
+              </h3>
+              <p class="muted agency-item__desc">
+                Focuses on workforce development and training programs in
+                Hokkaido.
+              </p>
+              <a
+                class="btn btn-secondary"
+                href="https://hhd.or.jp/"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Visit Hokkaido HRD</a
+              >
+            </li>
+          </ul>
         </section>
 
-        <p class="mt-lg">
-          <a class="btn btn-primary" href="../index.html">Back to Home</a>
+        <section class="feature-card mt-md" aria-labelledby="tokyo-rso-heading">
+          <h2 id="tokyo-rso-heading" class="feature-card__title">
+            Registered Support Organizations — Tokyo
+          </h2>
+          <p class="muted feature-card__desc">
+            A selection of Registered Support Organizations (RSOs) located in
+            Tokyo with contact information.
+          </p>
+
+          <ul class="agency-list mt-md">
+            <li class="agency-item">
+              <h3 class="agency-item__name">First Stakes Corp.</h3>
+              <p class="muted agency-item__desc">
+                Address: 7-4-7-5F, Nishishinjuku, Shinjuku-ku, Tokyo
+              </p>
+              <p class="muted agency-item__desc">
+                Phone: <a href="tel:+81353120271">03-5312-0271</a>
+              </p>
+            </li>
+
+            <li class="agency-item">
+              <h3 class="agency-item__name">
+                CALICO LEGAL Immigration Support
+              </h3>
+              <p class="muted agency-item__desc">
+                Address: 409, Tensho Office Bldg, 3-3-5, Nihonbashi Ningyo-cho,
+                Chuo-ku, Tokyo
+              </p>
+              <p class="muted agency-item__desc">
+                Phone: <a href="tel:+81336695200">03-3669-5200</a>
+              </p>
+            </li>
+
+            <li class="agency-item">
+              <h3 class="agency-item__name">
+                TSUKASA TSB CARE ACADEMY Co., Ltd
+              </h3>
+              <p class="muted agency-item__desc">
+                Address: Aiku-bldg, 5-5-1 Kokuryo-cho, Chofu-shi, Tokyo
+              </p>
+              <p class="muted agency-item__desc">
+                Phone: <a href="tel:+81424428130">042-442-8130</a>
+              </p>
+            </li>
+
+            <li class="agency-item">
+              <h3 class="agency-item__name">
+                General Incorporated Foundation CHIKYUJIN (Tokyo HQ)
+              </h3>
+              <p class="muted agency-item__desc">
+                Address: Kisho Bldg. 8F Sotokanda, Chiyoda-ku, Tokyo
+              </p>
+              <p class="muted agency-item__desc">
+                Phone: <a href="tel:+81335258148">03-3525-8148</a>
+              </p>
+            </li>
+
+            <li class="agency-item">
+              <h3 class="agency-item__name">
+                General Incorporated Foundation CHIKYUJIN (Tokyo Branch)
+              </h3>
+              <p class="muted agency-item__desc">
+                Address: 6F, 3-3-7 Bakurocho, Chuo-ku, Tokyo
+              </p>
+            </li>
+
+            <li class="agency-item">
+              <h3 class="agency-item__name">
+                KYUSHU NET COOPERATIVE (Tokyo branch)
+              </h3>
+              <p class="muted agency-item__desc">
+                Address: Oshidatemachi, Fuchu-city, Tokyo
+              </p>
+            </li>
+
+            <li class="agency-item">
+              <h3 class="agency-item__name">
+                Support Center Fukuoka YUKARI Life Support Center (Tokyo office)
+              </h3>
+              <p class="muted agency-item__desc">
+                Address: Kamikawabata-Machi, Hakata-ku, Tokyo
+              </p>
+            </li>
+
+            <li class="agency-item">
+              <h3 class="agency-item__name">
+                Non-Profit Organization Global Life
+              </h3>
+              <p class="muted agency-item__desc">
+                Address: 12-28 Kamikawabata-Machi, Hakata-ku, Tokyo
+              </p>
+            </li>
+
+            <li class="agency-item">
+              <h3 class="agency-item__name">
+                Shinichi Kato Office (Administrative scrivener and social
+                insurance worker)
+              </h3>
+              <p class="muted agency-item__desc">
+                Address: 3-1-27 Shinkawa-cho, Noboribetsu-shi, Tokyo
+              </p>
+            </li>
+
+            <li class="agency-item">
+              <h3 class="agency-item__name">
+                General Incorporated Association HASEGAWA
+              </h3>
+              <p class="muted agency-item__desc">
+                Address: 4-2-39 Fudomae, Utsunomiya-shi, Tochigi-ken, Tokyo
+              </p>
+            </li>
+          </ul>
+        </section>
+
+        <p class="mt-lg" style="text-align: center;">
+          <a class="btn btn-primary btn--small" href="../index.html"
+            >Back to Home</a
+          >
         </p>
       </div>
     </main>

--- a/pages/createAccount.html
+++ b/pages/createAccount.html
@@ -15,9 +15,14 @@
         <main>
 
         <div class="flex w-full max-w-6xl h-[80vh] bg-white rounded-xl shadow-lg overflow-hidden mx-auto my-12">
-        <!-- Left Panel - JapanSSW -->
-        <div class="hidden md:flex flex-col w-1/2 p-8 bg-gray-100 border-r border-gray-200">
-            <h1 class="text-3xl font-Inter text-red-600">Japan<b>SSW</b></h1>
+        <!-- Left Panel - JapanSSW (image for desktop) -->
+        <div class="hidden md:flex relative items-center justify-center w-1/2 p-0 bg-gray-100 border-r border-gray-200">
+            <!-- JapanSSW title kept visible above the image -->
+            <h1 class="absolute top-8 left-8 z-20 text-2xl md:text-3xl lg:text-4xl font-Inter text-red-600 drop-shadow-md bg-white bg-opacity-75 px-3 py-1 rounded-md">Japan<b>SSW</b></h1>
+            <picture class="w-full h-full">
+                <source type="image/webp" srcset="../assets/images/aiImages/Applying1-640.webp 640w, ../assets/images/aiImages/Applying1-320.webp 320w">
+                <img src="../assets/images/aiImages/Applying1.jpg" alt="Applicant filling form" class="object-cover w-full h-full" loading="lazy" />
+            </picture>
         </div>
 
         <!-- Right Panel - Create an account Form -->

--- a/pages/signin.html
+++ b/pages/signin.html
@@ -15,9 +15,14 @@
         <main>
 
         <div class="flex w-full max-w-6xl h-[80vh] bg-white rounded-xl shadow-lg overflow-hidden mx-auto my-12">
-        <!-- Left Panel - JapanSSW -->
-        <div class="hidden md:flex flex-col w-1/2 p-8 bg-gray-100 border-r border-gray-200">
-            <h1 class="text-3xl font-Inter text-red-600">Japan<b>SSW</b></h1>
+        <!-- Left Panel - JapanSSW (image for desktop) -->
+        <div class="hidden md:flex relative items-center justify-center w-1/2 p-0 bg-gray-100 border-r border-gray-200">
+            <!-- JapanSSW title kept visible above the image -->
+            <h1 class="absolute top-8 left-8 z-20 text-2xl md:text-3xl lg:text-4xl font-Inter text-red-600 drop-shadow-md bg-white bg-opacity-75 px-3 py-1 rounded-md">Japan<b>SSW</b></h1>
+            <picture class="w-full h-full">
+                <source type="image/webp" srcset="../assets/images/aiImages/Applying1-640.webp 640w, ../assets/images/aiImages/Applying1-320.webp 320w">
+                <img src="../assets/images/aiImages/Applying1.jpg" alt="Applicant filling form" class="object-cover w-full h-full" loading="lazy" />
+            </picture>
         </div>
 
         <!-- Right Panel - Login Form -->


### PR DESCRIPTION
This pull request introduces significant improvements to the agency listing and account/sign-in page layouts, focusing on better content presentation and enhanced visual design. The most important changes are grouped below by theme.

**Agency Listings:**

* The placeholder content in `pages/agency.html` was replaced with two detailed sections listing Registered Support Organizations (RSOs), including organization names, descriptions, and contact information, organized by region (general and Tokyo-specific).
* A new responsive card/grid layout for agency lists was added to `assets/css/main.css`, including styles for `.agency-list`, `.agency-item`, and related classes, ensuring the list adapts to different screen sizes and improves readability.

**Button and Navigation Enhancements:**

* A `.btn--small` modifier was introduced in `assets/css/main.css` for smaller secondary action buttons, and the "Back to Home" button on the agency page now uses this style for improved visual hierarchy. [[1]](diffhunk://#diff-b15932692c619f9a334ecb156ac167557c3af214a8a3df8990c09232ac8a5baaR165-R170) [[2]](diffhunk://#diff-19d2920ef265f8cad54104a84740b2439d8a92866195ae0ddb54697b82709edfL41-R222)

**Account and Sign-in Page Visuals:**

* The left panel on both `pages/createAccount.html` and `pages/signin.html` was redesigned to feature a background image of an applicant filling a form, with the `JapanSSW` title overlayed for better branding and a more engaging user experience. [[1]](diffhunk://#diff-35f393026831fb908b1e6c0826a2dd4e4618f377b509f74f02d8c3030bf055f5L18-R25) [[2]](diffhunk://#diff-a184dc435e9b224ee0e1c39edc0f8fa03ede883c10e8b9ad1a9942925f8780a0L18-R25)