### PR TITLE
Fix link references for Visa Guidance across multiple pages

### DIFF
--- a/pages/about.html
+++ b/pages/about.html
@@ -162,7 +162,7 @@
           <div class="link-col site-footer__link-col">
             <h4>Resources</h4>
             <ul>
-              <li><a href="#">Visa Guidance</a></li>
+              <li><a href="visaGuidance.html">Visa Guidance</a></li>
               <li><a href="#">Employer Hub</a></li>
               <li><a href="/pages/privacy.html">Privacy</a></li>
             </ul>

--- a/pages/agency.html
+++ b/pages/agency.html
@@ -256,7 +256,7 @@
           <div class="link-col site-footer__link-col">
             <h4>Resources</h4>
             <ul>
-              <li><a href="#">Visa Guidance</a></li>
+              <li><a href="visaGuidance.html">Visa Guidance</a></li>
               <li><a href="#">Employer Hub</a></li>
               <li><a href="privacy.html">Privacy</a></li>
             </ul>

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -134,7 +134,7 @@
           <div class="link-col site-footer__link-col">
             <h4>Resources</h4>
             <ul>
-              <li><a href="#">Visa Guidance</a></li>
+              <li><a href="visaGuidance.html">Visa Guidance</a></li>
               <li><a href="#">Employer Hub</a></li>
               <li><a href="privacy.html">Privacy</a></li>
             </ul>

--- a/pages/createAccount.html
+++ b/pages/createAccount.html
@@ -94,7 +94,7 @@
                     <div class="link-col site-footer__link-col">
                         <h4>Resources</h4>
                         <ul>
-                            <li><a href="visa-guidance.html">Visa Guidance</a></li>
+                            <li><a href="visaGuidance.html">Visa Guidance</a></li>
                             <li><a href="#">Employer Hub</a></li>
                             <li><a href="privacy.html">Privacy</a></li>
                         </ul>

--- a/pages/services.html
+++ b/pages/services.html
@@ -105,9 +105,9 @@
           <div class="link-col site-footer__link-col">
             <h4>Resources</h4>
             <ul>
-              <li><a href="../pages/visaGuidance.html">Visa Guidance</a></li>
+              <li><a href="visaGuidance.html">Visa Guidance</a></li>
               <li><a href="#">Employer Hub</a></li>
-              <li><a href="../pages/privacy.html">Privacy</a></li>
+              <li><a href="privacy.html">Privacy</a></li>
             </ul>
           </div>
         </div>

--- a/pages/signin.html
+++ b/pages/signin.html
@@ -93,7 +93,7 @@
                     <div class="link-col site-footer__link-col">
                         <h4>Resources</h4>
                         <ul>
-                            <li><a href="visa-guidance.html">Visa Guidance</a></li>
+                            <li><a href="visaGuidance.html">Visa Guidance</a></li>
                             <li><a href="#">Employer Hub</a></li>
                             <li><a href="privacy.html">Privacy</a></li>
                         </ul>


### PR DESCRIPTION
This pull request updates the "Resources" section in the site footer across multiple pages to consistently use the correct file names and paths for the "Visa Guidance" and "Privacy" links. These changes improve navigation reliability and maintain uniformity in link references throughout the site.

Footer link consistency updates:

* Changed the "Visa Guidance" link to use `visaGuidance.html` instead of `visa-guidance.html` or relative paths in `pages/createAccount.html`, `pages/signin.html`, `pages/services.html`, `pages/about.html`, `pages/agency.html`, and `pages/contact.html`. [[1]](diffhunk://#diff-35f393026831fb908b1e6c0826a2dd4e4618f377b509f74f02d8c3030bf055f5L97-R97) [[2]](diffhunk://#diff-a184dc435e9b224ee0e1c39edc0f8fa03ede883c10e8b9ad1a9942925f8780a0L96-R96) [[3]](diffhunk://#diff-aa392b78126942c7046e7dfb2a9ee2363f5457043156857552500bf26e5955caL108-R110) [[4]](diffhunk://#diff-9ddfd3b5b96d22475bea3d6477e507613fd0ddd610444a2189f01543414357f1L165-R165) [[5]](diffhunk://#diff-19d2920ef265f8cad54104a84740b2439d8a92866195ae0ddb54697b82709edfL259-R259) [[6]](diffhunk://#diff-0eef6cb1c700ba38bff462ac592e85966b14caedb195607c72e5c442c076b425L137-R137)
* Updated the "Privacy" link to use `privacy.html` instead of relative paths in `pages/services.html` and ensured consistency in other pages. [[1]](diffhunk://#diff-aa392b78126942c7046e7dfb2a9ee2363f5457043156857552500bf26e5955caL108-R110) [[2]](diffhunk://#diff-19d2920ef265f8cad54104a84740b2439d8a92866195ae0ddb54697b82709edfL259-R259) [[3]](diffhunk://#diff-0eef6cb1c700ba38bff462ac592e85966b14caedb195607c72e5c442c076b425L137-R137) [[4]](diffhunk://#diff-35f393026831fb908b1e6c0826a2dd4e4618f377b509f74f02d8c3030bf055f5L97-R97) [[5]](diffhunk://#diff-a184dc435e9b224ee0e1c39edc0f8fa03ede883c10e8b9ad1a9942925f8780a0L96-R96)